### PR TITLE
👷 labelerにGITHUB_TOKENを渡す

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -9,6 +9,8 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    with:
+      repo-token: "${{ secrets.GITHUB_TOKEN }}"
     steps:
     - id: label-the-PR
       uses: actions/labeler@v5


### PR DESCRIPTION
GITHUB_TOKENが渡せてなかったため、正常に動いていなかった...
